### PR TITLE
fix(webapp): Brand v6

### DIFF
--- a/branding/constants/logos.js
+++ b/branding/constants/logos.js
@@ -2,9 +2,11 @@
 // this are the paths in the webapp
 export default {
   LOGO_HEADER_PATH: '/img/custom/logo-horizontal.svg',
+  LOGO_HEADER_TABLET_PATH: '/img/custom/logo-horizontal.svg',
   LOGO_HEADER_MOBILE_PATH: '/img/custom/logo-horizontal.svg',
   LOGO_HEADER_WIDTH: '260px',
-  LOGO_HEADER_MOBILE_WIDTH: '260px',
+  LOGO_HEADER_TABLET_WIDTH: '215px',
+  LOGO_HEADER_MOBILE_WIDTH: '170px',
   LOGO_HEADER_CLICK: {
     // externalLink: {
     //   url: 'https://ocelot.social',


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Simulation brand reformer.network – v5

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->

- relates #8007 
- sync mit https://github.com/IT4Change/reformer.network/pull/19

### Todo allgemein
<!-- In case some parts are still missing, list them here. -->

- [ ] Interne Seiten:
  - [x] allgemein:
    - [x] Links bei Hover türlis machen
    - [x] Hier wird das Netzwerk `Reformer.Network` geschrieben. Im Logo wird es aber so geschrieben: `Reformer.network`.
    - [x] Ich habe die Kaufmännischen-Und `&` ersetzt mit `und`.
    - [x] Englische internen Seiten auf das Deutsche setzen?
      - [x] Mit ChatGPT übersetzen.
`Förderrichtlinien`.
  - [ ] Förderrichtlinien
    - [ ] Es wird auf die Förderrichtlinien an verschiedenen Stellen verwiesen. Sollen die doch wohin? Siehe unten 
    - [ ] Auf interne Extraseite
  - [x] Verhaltensrichtlinien
    - [x] Die `Plattformregeln` sind irgendwie die Kurzfassung. Was soll ich damit tun?
  - [x] Rechliches
    - [x] Ein Abschnitt war nicht nummeriert. Ich habe ihn nummeriert. War das richtig?
  - [x] Mit ❤️ gemacht
    - [x] Titel zu `Über uns` ändern.
    - [x] Inhalt: liefert Markus
  - [x] Spenden
    - [x] Da fehlen informationen.
raseite, die nur per Link erreichbar ist
  - [ ] Support
    - [ ] Die Support-Seite mit dem Chat ausstatten, der auf Masernexpress ist, ganz unten das Chat-Symol übernehmen: https://masern-impfblocker.de/
- [ ] Design anpassen, siehe [Reformer-network_Design-Feedback_2025-04-14.pdf](https://github.com/user-attachments/files/19763362/Reformer-network_Design-Feedback_2025-04-14.pdf)
  - [x] Hell-Türkis Farbangabe stimmt nicht im PDF
    - [x] Ich hab jetzt aus dem PDF gemessen: rgb(182, 228, 234) | #b6e4ea
  - [x] Square-Logo für Login etc. erneuern
  - [x] Schrift durch Inter (regular + Bold) ersetzen
  - [x] Leeres Avatar-Bild im Nutzerprofil umfärben ???
    - [x] Ich meine, es ist okay.
  - [x] Komplettes Farbschema von Primary zu Secondary ausgetauscht und angepasst:
    - [x] Linkfarben angepasst
    - [x] Kopfzeile alles angepasst
    - [x] Fußzeile alles angepasst
  - [x] Button-Farbe und deren Hover-Farbe generell austauschen?
  - [x] Eingabefeld-Umrandungsfarbe
  - [x] Check-Box-Farbe ändern, suche nach `type="checkbox"`:
    - [x] Registration
    - [x] Settings
    - [x] Post, Veranstaltung
    - [x] Terms and Condition Agreement
    - [x] etc.
  - [x] User-Teaser:
    - [x] Slug bei Hover türkis machen
  - [x] Texte: (see https://github.com/Ocelot-Social-Community/Ocelot-Social/pull/8507 )
    - [x] Du → du
    - [x] Dich → dich
  - [x] Banderolen:
    - [x] Meldung → hellblau
    - [x] Beitrag → Türkis
    - [x] Veranstaltung:
      - [x] hier Farbe überprüfen, siehe Bildschirmfoto
  - [x] Plus-Knopf für Beiträge farblich angepasst:
    - [x] Mittelgrau
    - [x] Hover: Antrazit
  - [x] Chat komplett:
    - [x] diverses angepasst
  - [ ] Login, Registrierung, Passwort-Zurücksetzen:
    - [x] Bild in den Hintergrund:
      - [x] `http://localhost:3000/registration`
      - [x] `http://localhost:3000/login`
      - [x] `http://localhost:3000/password-reset`
      - [ ] neue vorgeschaltete Seite mit Anmelde-Knopf als Landing-Page
        - [ ] nur, wenn es sonst mobil nicht aussieht
    - [ ] Sondertext
      - [x] `http://localhost:3000/registration`
      - [x] `http://localhost:3000/login`
      - [ ] `http://localhost:3000/password-reset`
      - [ ] neue vorgeschaltete Seite mit Anmelde-Knopf als Landing-Page
        - [ ] nur, wenn es sonst mobil nicht aussieht  - [ ] E-Mails:
  - [ ] E-Mail-Design:
    - [ ] https://github.com/Ocelot-Social-Community/Ocelot-Social/issues/8487
    - [ ] Button-Farbe und deren Hover-Farbe ersetzen
    - [ ] Linienfarbe ersetzen

### Fehler und Fragen

- [ ] Design:
  - [x] Organisation stimmt inhaltlich nicht
  - [x] Menüs mit organgen Links anders kolorieren, siehe Screen-Shot (rotes Logout bleibt vermutlich):
    - [x] Designerin sagt:
      - [x] Ja, das Orange ist schwer zu lesen. Wie wäre es ganz schlicht: ein mittleres Grau (secondary color) für Standard, und Schwarz (black) bei Hover?
      - [x] Ebenso könnte es bei den Mailadressen (Red. User-Teaser) der Beiträge sein - aktuell lenken die doch arg vom Inhalt ab.
  - [x] Fußzeile:
    - [x] Hover-Farbe anders:
      - [x] Designerin sagt:
        - [x] Ja, Weiß wäre besser. Was für eine Farbe ist dieser Standard? Ein blasses Türkis? Blassgrau wäre passender.
    - [x] Schrift: Meine Frage an Stephanie: Ich würde auch vorschlagen die Schrift in der Fußzeile doch nicht in Bold zu machen.
      - [x] Designerin sagt:
        - [x] Ja okay, schau mal, ob Inter medium 500 noch gut lesbar ist auf dem Mittelgrau. Und Farbe bitte nicht blasstürkis, sondern blassgrau.
  - [x] Chat-Avatar: dunkel Türkis → `$color-secondary` (siehe Screen-Shot)
  - [x] interne Seiten: Überschriften: Inhalt ohne extra `Container`? Siehe Überschriften und Inhalt, `Verhaltensrichtlinien` Screen-Shots.
  - [x] Fokus Rahmen ist noch grün und sollte `$color-primary` sein:
    - [x] Suche, siehe Screen-Shot
    - [x] Einstellungen > Deine Daten > Deine Stadt oder Region
    - [x] Erstelle eine neue Gruppe > Deine Stadt oder Region
  - [ ] Login und Registration
    - [x] Sondertexte funktionieren nicht richtig
    - [ ] soll es lieber Extra-Bold anstatt Bold sein, wie Vorgabe
    - [ ] Mobil-Optimierung, siehe Screenshots (auch Issues #8457 bzw. https://github.com/IT4Change/reformer.network/pull/14 )

### Fehler und Fragen 2

- [x] Design:
  - [x] neue Logos mit extra URL `re-net.de`
  - [x] Chat:
    - [x] Message-Text doch auf schwarz setzen
    
<img width="1101" alt="Bildschirmfoto 2025-05-14 um 00 18 56" src="https://github.com/user-attachments/assets/dad17721-ab7e-4f34-970d-8b1d25348b45" />

<img width="1591" alt="Bildschirmfoto 2025-05-14 um 11 33 15" src="https://github.com/user-attachments/assets/52d63976-3d47-4757-b3d7-84b244228ae3" />

